### PR TITLE
fix: use lowercase dockerfile manager name

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["cynkra/renovate-config"],
-  "enabledManagers": ["Dockerfile", "regex", "woodpecker"],
+  "enabledManagers": ["dockerfile", "regex", "woodpecker"],
   "forkProcessing": "enabled",
   "customManagers": [
     {


### PR DESCRIPTION
## Summary
- Fixes the dockerfile manager name to use lowercase in renovate.json (see also see also https://github.com/cynkra/runner/issues/2)

## Test plan
- Renovate should correctly detect and process Dockerfile updates with the corrected manager name